### PR TITLE
feat: click notification to open/focus sending application

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -155,6 +155,53 @@ BarWidget {
     rebuildRows()
   }
 
+  // ---- Focus / launch the app that sent a notification.
+  // Uses omarchy-launch-or-focus when available (exact word-boundary match on
+  // window class/title).  Falls back to a direct hyprctl lookup so the feature
+  // works even on minimal installs.
+  property string focusTarget: ""
+
+  function focusApp(appName) {
+    var name = String(appName || "").trim()
+    if (name === "" || name === "notify-send" || name === "omarchy-action") return
+    root.focusTarget = name
+    focusLookup.command = ["hyprctl", "clients", "-j"]
+    focusLookup.running = true
+  }
+
+  function resolveFocusFromClients(json) {
+    var target = root.focusTarget
+    if (!target) return
+    try {
+      var clients = JSON.parse(json)
+      var needle = target.toLowerCase()
+      var best = null
+      for (var i = 0; i < clients.length; i++) {
+        var c = clients[i]
+        if (!c) continue
+        var cls = String(c["class"] || "").toLowerCase()
+        var title = String(c["title"] || "").toLowerCase()
+        if (cls === needle || title === needle ||
+            cls.indexOf(needle) >= 0 || title.indexOf(needle) >= 0 ||
+            needle.indexOf(cls) >= 0) {
+          best = c
+          break
+        }
+      }
+      if (best && best.address) {
+        focusDispatch.command = ["hyprctl", "dispatch", "focuswindow", "address:" + best.address]
+        focusDispatch.running = true
+        root.close()
+        return
+      }
+    } catch (e) { /* ignore parse errors */ }
+
+    // No matching window found — try to launch via omarchy-launch-or-focus.
+    focusLaunch.command = ["omarchy-launch-or-focus", target]
+    focusLaunch.running = true
+    root.close()
+  }
+
   function clearSearch() {
     root.query = ""
     searchField.text = ""
@@ -233,6 +280,25 @@ BarWidget {
       waitForEnd: true
       onStreamFinished: root.parseHistory(text)
     }
+  }
+
+  Process {
+    id: focusLookup
+    running: false
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.resolveFocusFromClients(text)
+    }
+  }
+
+  Process {
+    id: focusDispatch
+    running: false
+  }
+
+  Process {
+    id: focusLaunch
+    running: false
   }
 
   Connections {
@@ -449,14 +515,14 @@ BarWidget {
           color: "transparent"
           borderSpec: Border.flat(root.colBorder, Style.normalBorderWidth)
 
-          // Left click dismisses. Hover reveals a dedicated close (x)
-          // button as an alternate, more discoverable way to dismiss.
+          // Left-click opens/focuses the sending application.
+          // Hover reveals a dedicated close (x) button for dismissal.
           MouseArea {
             id: rowHoverArea
             anchors.fill: parent
             hoverEnabled: true
             cursorShape: Qt.PointingHandCursor
-            onClicked: root.dismiss(rowCard.modelData)
+            onClicked: root.focusApp(rowCard.modelData.app)
           }
 
           RowLayout {
@@ -607,7 +673,7 @@ BarWidget {
       // ----------------------------------------- footer legend
       Text {
         Layout.fillWidth: true
-        text: "Left-click or hover the ✕ to dismiss · Esc closes"
+        text: "Click to open app · Hover ✕ to dismiss · Esc closes"
         font.family: root.bar ? root.bar.fontFamily : ""
         color: Qt.darker(root.colForeground, 1.55)
         font.pixelSize: Style.font.caption

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ In the preview I am using my custom "Ame-quattro" theme, feel free to check: htt
 - **Live notifications** from Omarchy's first-party notification service.
 - **Persistent notification history** maintained by Omarchy.
 - History is shown without replaying old notifications as new popups.
+- **Click a notification to open or focus the sending application** (uses `hyprctl` under the hood; falls back to `omarchy-launch-or-focus` when available).
 - Search notifications by application, title, or body.
 - Individual dismissal for live notifications.
 - Clear all live notifications and saved history.
@@ -94,6 +95,14 @@ Test it with:
 ```bash
 notify-send -a "Test" "Notification Center" "Hello from Omarchy!"
 ```
+
+### Click to open application
+
+Clicking a notification in the panel will focus the window of the application
+that sent it. If the application is not running, it will be launched via
+`omarchy-launch-or-focus`.
+
+To dismiss a notification instead, hover over it and click the **✕** button.
 
 ## How it works
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "shavanced.notification-center",
   "name": "Notification Center",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": "Shavanced",
   "license": "MIT",
   "description": "A native Omarchy notification center with live notifications, persistent history, search, Do Not Disturb, and a theme-aware bar widget.",


### PR DESCRIPTION
## Summary

Left-clicking a notification now **focuses the window** of the application that sent it, or **launches the app** if no matching window is found. This is the standard behavior in GNOME/KDE notification centers and has been missing from this plugin.

## What changed

- **BarWidget.qml**: Added `focusApp()`, `resolveFocusFromClients()`, and three `Process` elements (`focusLookup`, `focusDispatch`, `focusLaunch`)
- **README.md**: Documented the new click-to-open behavior
- **manifest.json**: Bumped version to 1.4.0

## How it works

1. Click a notification → runs `hyprctl clients -j` to find a window whose `class` or `title` matches the notification's `appName`
2. If a match is found → `hyprctl dispatch focuswindow address:...` to focus it
3. If no match → falls back to `omarchy-launch-or-focus` to launch the app
4. Ephemeral apps (`notify-send`, `omarchy-action`) are skipped
5. Dismiss is now via the hover **✕** button only

## UX rationale

| Before             | After                                  |
| ------------------ | -------------------------------------- |
| Left-click → dismiss | Left-click → open/focus app          |
| Hover → X → dismiss | Hover → X → dismiss (unchanged)     |

This matches the convention of GNOME, KDE, and Windows notification centers where clicking a notification takes you to the source.

## Testing

```bash
# Send a test notification, open the panel, click it
notify-send -a "Firefox" "Test" "Click me to focus Firefox"
notify-send -a "Spotify" "Now Playing" "Song name"
```

Clicking the Firefox notification should focus the Firefox window. Clicking Spotify should focus Spotify. If the app isn't running, it should launch it.