### PR TITLE
Update BarWidget.qml

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -271,7 +271,7 @@ BarWidget {
     bar: root.bar
     owner: root
     open: root.popupOpen
-    contentWidth: popup.fittedContentWidth(Style.space(440))
+    contentWidth: popup.fittedContentWidth(Style.space(380))
     contentHeight: popup.cappedContentHeight(Style.space(540))
 
     ColumnLayout {


### PR DESCRIPTION
Small change to make the popup window the same width as other Omarchy popups (network, sound, bluetooth, etc).

It does squash the notifications a little, but looks much more seamless this way. Feel free to reject the PR if you prefer the wider width.