### PR TITLE
fix(bar): expose notification panel controls

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -26,6 +26,8 @@ BarWidget {
   moduleName: "shavanced.notification-center"
 
   property bool popupOpen: false
+  readonly property bool opened: popupOpen
+  function open() { popupOpen = true }
   function close() { popupOpen = false }
 
   property string query: ""


### PR DESCRIPTION
## Summary

- expose the `opened` state and `open()` method on the notification center bar widget
- keep the existing `close()` behavior

## Root cause

Omarchy's current bar router only treats a bar widget as a summonable panel when it exposes `open()`, `close()`, and `opened`. The notification center only exposed `close()`, so shell toggles returned `no live bar widget` even though the icon was installed and visible.

## Verification

- `omarchy plugin validate .`
- `qmllint BarWidget.qml`
- `omarchy-shell shell summon shavanced.notification-center '{}'` returned `ok`
- `omarchy-shell shell hide shavanced.notification-center` completed without a live-widget warning
- `org.freedesktop.Notifications` responds from the running Quickshell process
