### PR TITLE
Fix keyboard focus in search field

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -210,11 +210,6 @@ BarWidget {
       clearSearch()
       refreshHistory()
       rebuildRows()
-      // Explicitly grab keyboard focus for the search field. Without this,
-      // a wlr-layer-shell popup can render and accept mouse clicks while
-      // still not reliably routing keystrokes to a child TextField, which
-      // is what made typing feel inconsistent.
-      Qt.callLater(function() { if (root.popupOpen) searchField.forceActiveFocus() })
     }
   }
   onQueryChanged: rebuildRows()
@@ -265,12 +260,13 @@ BarWidget {
     }
   }
 
-  PopupCard {
+  KeyboardPanel {
     id: popup
     anchorItem: button
     bar: root.bar
     owner: root
     open: root.popupOpen
+    focusTarget: searchField
     contentWidth: popup.fittedContentWidth(Style.space(440))
     contentHeight: popup.cappedContentHeight(Style.space(540))
 


### PR DESCRIPTION
## Problem

Opening the notification center from the bar icon sometimes leaves the search field unable to receive keyboard input — typing does nothing until the popup is clicked first.

## Cause

The popup is a `PopupCard`, which is an xdg-popup. xdg-popups only route keystrokes after a click (or hover) routes focus through their parent surface, so a popup opened from the bar button never receives keyboard focus on its own. The existing `Qt.callLater(... searchField.forceActiveFocus())` workaround only sets Qt's internal active focus; it cannot make the compositor grant keyboard focus to the surface.

## Fix

Use Omarchy's `KeyboardPanel` (`qs.Ui`) instead of `PopupCard`. `KeyboardPanel` is a layer-shell popup built for exactly this case: it primes keyboard focus on open (brief `WlrKeyboardFocus.Exclusive`, then settles on `OnDemand`) and focuses the declared `focusTarget` once the surface maps. Setting `focusTarget: searchField` makes typing work immediately when the center opens.

## Notes

- `KeyboardPanel` exposes the same `anchorItem` / `bar` / `owner` / `open` / content API used here, so the change is a drop-in for the popup container.
- The manual `Qt.callLater` focus workaround is removed; `KeyboardPanel` handles focus priming and target focus internally.
- Tested on Omarchy (Quickshell): typing in the search field works on every open, with no click-first requirement.
